### PR TITLE
Remove GH Actions workflow for docs

### DIFF
--- a/.github/workflows/.pre-commit.yml
+++ b/.github/workflows/.pre-commit.yml
@@ -21,6 +21,3 @@ jobs:
 
       - name: Flake8
         run: poetry run flake8
-
-      - name: Generate Docs
-        run: pdoc --html --output-dir docs pom_elements --force


### PR DESCRIPTION
I am removing the docs Github Actions workflow until I can better figure
out where the docs directory will live. The project needs to be public
before I start generating docs for this project. Also, to accomplish
auto-published docs setup as seen in pdoc, then we will need to move the
docs directory to its own github repo.

GH-13